### PR TITLE
feat: Google OAuth2 Redirect URI 수정

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -33,6 +33,7 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${BASE_URL}/oauth2/callback/google
             scope:
             - email
             - profile


### PR DESCRIPTION
## 📌 제목
feat: Google OAuth2 Redirect URI 수정

----------------------------------------

## 🔗 관련 이슈
- Close #23 

## ✅ 작업 내용
- Google OAuth2 Redirect_URI 네이버와 카카오와 통일시킴

## 📝 기타 참고 사항
- 테스트 방법, 추가로 공유할 내용

