### PR TITLE
feat: 백오피스 리뷰 관리rd api 구현

### DIFF
--- a/src/main/java/com/seoulotakus/takumapbe/domain/review/controller/BackofficeReviewController.java
+++ b/src/main/java/com/seoulotakus/takumapbe/domain/review/controller/BackofficeReviewController.java
@@ -1,0 +1,50 @@
+package com.seoulotakus.takumapbe.domain.review.controller;
+
+import com.seoulotakus.takumapbe.domain.review.dto.response.BackofficeReviewResponse;
+import com.seoulotakus.takumapbe.domain.review.service.ReviewService;
+import com.seoulotakus.takumapbe.domain.user.entity.UserEntity;
+import com.seoulotakus.takumapbe.global.response.ApiResponse;
+import com.seoulotakus.takumapbe.global.util.CurrentUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/backoffice/reviews")
+public class BackofficeReviewController {
+
+    private final ReviewService reviewService;
+
+    /**
+     * 내 가게 리뷰 목록 조회
+     * [Check 1] ROLE_BOSS 권한 확인 (Service 내부)
+     * [Check 2] 본인 소유 가게의 리뷰만 조회 (Repository Query + JWT ID)
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<BackofficeReviewResponse>>> getMyShopReviews(
+            @CurrentUser UserEntity user,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<BackofficeReviewResponse> response = reviewService.getReviewForManager(user, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response, "내 가게 리뷰 목록 조회 성공"));
+    }
+
+    /**
+     * 리뷰 삭제 (사장님 권한)
+     * [Check 1] ROLE_BOSS 권한 확인 (Service 내부)
+     * [Check 2] 해당 리뷰가 내 가게의 리뷰인지 확인 (Service 내부 Java Logic)
+     */
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<ApiResponse<Void>> deleteReviewByManager(
+            @PathVariable Long reviewId,
+            @CurrentUser UserEntity user
+    ) {
+        reviewService.deleteReviewByManager(reviewId, user);
+        return ResponseEntity.ok(ApiResponse.success(null, "리뷰 삭제(관리) 성공"));
+    }
+}

--- a/src/main/java/com/seoulotakus/takumapbe/domain/review/dto/response/BackofficeReviewResponse.java
+++ b/src/main/java/com/seoulotakus/takumapbe/domain/review/dto/response/BackofficeReviewResponse.java
@@ -1,0 +1,34 @@
+package com.seoulotakus.takumapbe.domain.review.dto.response;
+
+import com.seoulotakus.takumapbe.domain.review.dto.common.ImageDTO;
+import com.seoulotakus.takumapbe.domain.review.entity.Review;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class BackofficeReviewResponse {
+    private Long reviewId;
+    private Long shopId;
+    private String shopName;
+    private Long writerId;
+    private String writerNickname;
+    private BigDecimal rating;
+    private String content;
+    private List<ImageDTO> images;
+    private LocalDateTime createdAt;
+
+    public BackofficeReviewResponse(Review review, List<ImageDTO> images) {
+        this.reviewId = review.getId();
+        this.shopId = review.getShop().getId();
+        this.shopName = review.getShop().getName();
+        this.writerId = review.getWriter().getId();
+        this.writerNickname = review.getWriter().getNickname();
+        this.rating = review.getRating();
+        this.content = review.getContent();
+        this.images = images;
+        this.createdAt = review.getCreatedAt();
+    }
+}

--- a/src/main/java/com/seoulotakus/takumapbe/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/seoulotakus/takumapbe/domain/review/repository/ReviewRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -28,4 +29,20 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Page<Review> findByShopIdWithWriter(Long shopId, Pageable pageable);
 
     Optional<Review> findByIdAndDeletedAtIsNull(Long reviewId);
+
+    /**
+     * [Backoffice] 사장님(ownerId)이 보유한 Shop에 작성된 리뷰들만 조회
+     * 조건 1: Review(r)와 Shop(s)을 조인
+     * 조건 2: Shop의 생성자(s.createdBy.id)가 현재 로그인한 유저(ownerId)와 같아야 함
+     * 조건 3: 삭제되지 않은 리뷰만 조회
+     */
+    @Query(value = """
+            SELECT r FROM Review r
+                JOIN FETCH r.shop s
+                JOIN FETCH r.writer w
+            WHERE s.createdBy.id = :ownerId
+              AND r.deletedAt IS NULL
+    """,
+            countQuery = "SELECT COUNT(r) FROM Review r JOIN r.shop s WHERE s.createdBy.id = :ownerId AND r.deletedAt IS NULL")
+    Page<Review> findAllByShopOwnerId(@Param("ownerId") Long ownerId, Pageable pageable);
 }

--- a/src/main/java/com/seoulotakus/takumapbe/domain/review/service/ReviewService.java
+++ b/src/main/java/com/seoulotakus/takumapbe/domain/review/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.seoulotakus.takumapbe.domain.review.service;
 import com.seoulotakus.takumapbe.domain.review.dto.common.ImageDTO;
 import com.seoulotakus.takumapbe.domain.review.dto.request.ReviewCreateRequest;
 import com.seoulotakus.takumapbe.domain.review.dto.request.ReviewUpdateRequest;
+import com.seoulotakus.takumapbe.domain.review.dto.response.BackofficeReviewResponse;
 import com.seoulotakus.takumapbe.domain.review.dto.response.ReviewDetailResponse;
 import com.seoulotakus.takumapbe.domain.review.dto.response.ReviewSingleResponse;
 import com.seoulotakus.takumapbe.domain.review.entity.Review;
@@ -10,6 +11,7 @@ import com.seoulotakus.takumapbe.domain.review.repository.ReviewRepository;
 import com.seoulotakus.takumapbe.domain.shop.entity.Shop;
 import com.seoulotakus.takumapbe.domain.shop.repository.ShopRepository;
 import com.seoulotakus.takumapbe.domain.user.entity.UserEntity;
+import com.seoulotakus.takumapbe.domain.user.enums.UserRole;
 import com.seoulotakus.takumapbe.global.exception.BusinessException;
 import com.seoulotakus.takumapbe.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -105,6 +107,63 @@ public class ReviewService {
 
         // Soft Delete
         review.softDelete(user);
+    }
+
+    // 백오피스 - 사장님 리뷰 RD
+
+    public Page<BackofficeReviewResponse> getReviewForManager (UserEntity user, Pageable pageable) {
+        // 1. 권한 체크 (ROLE_BOSS 여부)
+        validateBossRole(user);
+
+        // 2. JWT 유저 ID를 사용하여 Repository 조회
+        Page<Review> reviews = reviewRepository.findAllByShopOwnerId(user.getId(), pageable);
+
+        return reviews.map(review -> {
+            List<ImageDTO> images = helper.getReviewImages(review, 1);
+            return new BackofficeReviewResponse(review, images);
+        });
+    }
+
+    @Transactional
+    public void deleteReviewByManager(Long reviewId, UserEntity user) {
+        log.info("관리자(사장님) 리뷰 삭제 시도 - 리뷰 ID: {}, 요청자 ID: {}", reviewId, user.getId());
+
+        // 1. 권한 체크
+        validateBossRole(user);
+
+        // 2. 리뷰 조회
+        Review review = reviewRepository.findByIdAndDeletedAtIsNull(reviewId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        // 3. 소유권 체크
+        checkShopOwner(review, user);
+
+        // 4. Soft Delete 진행
+        review.softDelete(user);
+    }
+
+    // == 검증 로직 == //
+
+    /**
+     * 사용자가 사장님(ROLE_BOSS) 권한을 가지고 있는지 확인
+     */
+    private void validateBossRole(UserEntity user) {
+        if (user.getUserRole() != UserRole.ROLE_ADMIN) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+    }
+
+    /**
+     * 리뷰가 달린 상점의 주인이 현재 유저와 일치하는지 확인
+     */
+    private void checkShopOwner(Review review, UserEntity user) {
+        Long ownerId = review.getShop().getCreatedBy().getId();
+
+        if (!ownerId.equals(user.getId())) {
+            log.warn("타인의 상점 리뷰 삭제 시도 감지. OwnerId: {}, RequesterId: {}", ownerId, user.getId());
+
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
     }
 
 }

--- a/src/main/java/com/seoulotakus/takumapbe/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/seoulotakus/takumapbe/domain/user/entity/UserEntity.java
@@ -65,7 +65,7 @@ public class UserEntity{
     private LocalDateTime updatedAt;
 
     @Column(name = "updated_by")
-    private long updatedBy;
+    private Long updatedBy;
 
     public UserEntity update(String nickname, String email){
         this.nickname = nickname;


### PR DESCRIPTION
## 📌 제목
feat: 백오피스 리뷰 관리rd api 구현

----------------------------------------

## 🔗 관련 이슈
- Close #31 

## ✅ 작업 내용
- 리뷰 관리 RD api
    - get: /api/v1/backoffice/reviews (read)
    - delete: /api/v1/backoffice/reviews/{reviewId}
- user-updateBy 데이터가 비어있을 경우 npe 발생하여 UserEntity 수정함
    - /domain/user/entity/UserEntity.java
       : private (long -> )Long updatedBy;

## 📝 기타 참고 사항
- x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 백오피스 사용자가 자신의 가게에 등록된 리뷰를 한 눈에 확인할 수 있습니다. (페이지네이션 지원, 최신순 정렬)
* 백오피스 사용자가 자신의 가게에 등록된 리뷰를 삭제할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->